### PR TITLE
Changes to compile CleverRaven/Cataclysm-DDA#65709 with CMake

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -51,7 +51,6 @@ RGBTuple color_loader<RGBTuple>::from_rgb( const int r, const int g, const int b
 #else
 #include <imgui/imgui.h>
 #include <imgui/imgui_internal.h>
-#include <SDL2/SDL_pixels.h>
 #include "sdl_utils.h"
 #endif
 

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -849,7 +849,9 @@ void inventory_column::calculate_cell_width( size_t index )
             cells[index].current_width = text_stripped.length();
         }
     }
+#if defined( TILES )
     cells[index].current_width = ( cells[index].current_width + 1 ) * fontwidth;
+#endif
 }
 
 size_t inventory_column::next_highlightable_index( size_t index, scroll_direction dir ) const

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -1,4 +1,4 @@
-﻿#if defined(TILES)
+﻿#if defined( TILES )
 #include "sdl_font.h"
 
 #include "font_loader.h"
@@ -19,9 +19,9 @@
 
 #define dbg(x) DebugLog((x),D_SDL) << __FILE__ << ":" << __LINE__ << ": "
 
-// bitmap font size test
-// return face index that has this size or below
-static int test_face_size( const std::string &f, int size, int faceIndex )
+    // bitmap font size test
+    // return face index that has this size or below
+    static int test_face_size( const std::string &f, int size, int faceIndex )
 {
     const TTF_Font_Ptr fnt( TTF_OpenFontIndex( f.c_str(), size, faceIndex ) );
     if( fnt ) {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1106,7 +1106,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         };
 
         // draws a black rectangle behind a label for visibility and legibility
-        const auto label_bg = [&]( const tripoint_abs_sm & pos, const std::string &name ) {
+        const auto label_bg = [&]( const tripoint_abs_sm & pos, const std::string & name ) {
             const int name_length = utf8_width( name );
             const point draw_pos = abs_sm_to_draw_label( pos, name_length );
             SDL_Rect clipRect = { draw_pos.x, draw_pos.y, name_length * fontwidth, fontheight };
@@ -1170,7 +1170,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     if( !notes_window_text.empty() ) {
         constexpr int padding = 2;
 
-        const auto draw_note_text = [&]( const point & draw_pos, const std::string &name,
+        const auto draw_note_text = [&]( const point & draw_pos, const std::string & name,
         nc_color & color ) {
             char note_fg_color = color == c_yellow ? 11 :
                                  cata_cursesport::colorpairs[color.to_color_pair_index()].FG;

--- a/src/third-party/CMakeLists.txt
+++ b/src/third-party/CMakeLists.txt
@@ -10,13 +10,14 @@ add_library(
 
 set(THIRD_PARTY_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/third-party)
 
+# Flatbuffers
 file(GLOB FLATBUFFERS_HEADERS ${THIRD_PARTY_SOURCE_DIR}/flatbuffers/**/*.h)
 file(GLOB FLATBUFFERS_SOURCES ${THIRD_PARTY_SOURCE_DIR}/flatbuffers/*.cpp)
 
 add_library(
         flatbuffers
         STATIC
-        ${FLATBUFFER_HEADERS}
+        ${FLATBUFFERS_HEADERS}
         ${FLATBUFFERS_SOURCES})
 
 target_include_directories(
@@ -31,6 +32,13 @@ target_include_directories(
         PUBLIC
         ${CMAKE_SOURCE_DIR}/src)
 
+target_link_libraries(
+        third-party
+        INTERFACE
+        flatbuffers
+        )
+
+# GHC filesystem
 file(GLOB GHC_HEADERS ${THIRD_PARTY_SOURCE_DIR}/ghc/*.hpp)
 
 add_library(
@@ -51,5 +59,83 @@ target_include_directories(
 target_link_libraries(
         third-party
         INTERFACE
-        flatbuffers
-        ghc-filesystem)
+        ghc-filesystem
+        )
+
+# ImGUI
+if (TILES)
+        file(GLOB IMGUI_HEADERS ${THIRD_PARTY_SOURCE_DIR}/imgui/*.h)
+        file(GLOB IMGUI_SOURCES ${THIRD_PARTY_SOURCE_DIR}/imgui/*.cpp)
+
+        add_library(
+                imgui
+                STATIC
+                ${IMGUI_HEADERS}
+                ${IMGUI_SOURCES}
+                )
+
+        target_include_directories(
+                imgui
+                SYSTEM
+                PUBLIC
+                ${THIRD_PARTY_SOURCE_DIR}
+                )
+
+        target_include_directories(
+                imgui
+                SYSTEM
+                PRIVATE
+                ${SDL2_INCLUDE_DIR}/..
+                )
+
+        target_compile_options(
+                imgui
+                PRIVATE
+                -Wno-format
+                -Wno-old-style-cast
+                -Wno-unused-macros
+                -Wno-zero-as-null-pointer-constant
+                )
+
+        target_link_libraries(
+                third-party
+                INTERFACE
+                imgui
+                )
+endif ()
+
+# ImTUI
+if (CURSES)
+        file(GLOB IMTUI_HEADERS ${THIRD_PARTY_SOURCE_DIR}/imtui/*.h)
+        file(GLOB IMTUI_SOURCES ${THIRD_PARTY_SOURCE_DIR}/imtui/*.cpp)
+
+        add_library(
+                imtui
+                STATIC
+                ${IMTUI_HEADERS}
+                ${IMTUI_SOURCES}
+                )
+
+        target_include_directories(
+                imtui
+                SYSTEM
+                PUBLIC
+                ${THIRD_PARTY_SOURCE_DIR}
+                )
+
+        target_compile_options(
+                imtui
+                PRIVATE
+                -Wno-missing-declarations
+                -Wno-old-style-cast
+                -Wno-unused-macros
+                -Wno-unused-variable
+                -Wno-zero-as-null-pointer-constant
+                )
+
+        target_link_libraries(
+                third-party
+                INTERFACE
+                imtui
+                )
+endif ()

--- a/src/third-party/imtui/imtui-impl-ncurses.cpp
+++ b/src/third-party/imtui/imtui-impl-ncurses.cpp
@@ -289,7 +289,7 @@ bool is_in_bounds( int x, int y )
 {
     ImGuiContext *ctxt = ImGui::GetCurrentContext();
     // skip the first window, since ImGui seems to always have a "dummy" window that takes up most of the screen
-    for( size_t index = 1; index < ctxt->Windows.size(); index++ ) {
+    for( int index = 1; index < ctxt->Windows.size(); index++ ) {
         ImGuiWindow *win = ctxt->Windows[index];
         if(win->Collapsed || !win->Active) {
             continue;
@@ -353,7 +353,8 @@ void ImTui_ImplNcurses_DrawScreen( bool active )
         }
         bool wmove_needed = true;
 
-        int lastp = 0xFFFFFFFF;
+        constexpr int no_lastp = 0x7FFFFFFF;
+        int lastp = no_lastp;
         for( int x = 0; x < nx; ++x ) {
             if( !is_in_bounds( x, y ) ) {
                 wmove_needed = true;
@@ -381,7 +382,7 @@ void ImTui_ImplNcurses_DrawScreen( bool active )
             const uint16_t c = cell & 0x0000FFFF;
             waddch( imtui_win, c );
         }
-        if( lastp != 0xFFFFFFFF ) {
+        if( lastp != no_lastp ) {
             wattroff( imtui_win, COLOR_PAIR( colPairs[lastp].second ) );
         }
 


### PR DESCRIPTION
This will make your code in CleverRaven/Cataclysm-DDA#65709 compile with CMake, after fixing a few warnings. I also included a few fixes for warnings not related to upstream and unused variables, but not all warnings are fixed in case you need to use those ~~unsued~~ unused (oopsie) variables.