### PR TITLE
display custom keybind with *, again

### DIFF
--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -565,6 +565,7 @@ keybindings_ui::keybindings_ui( bool permit_execute_action,
     legend.push_back( colorize( _( "Unbound keys" ), unbound_key ) );
     legend.push_back( colorize( _( "Keybinding active only on this screen" ), local_key ) );
     legend.push_back( colorize( _( "Keybinding active globally" ), global_key ) );
+    legend.push_back( colorize( _( "* User created" ), global_key ) );
     if( permit_execute_action ) {
         legend.push_back( string_format(
                               _( "Press %c to execute action\n" ),
@@ -630,6 +631,9 @@ void keybindings_ui::draw_controls()
             bool overwrite_default;
             const action_attributes &attributes = inp_mngr.get_action_attributes( action_id, ctxt->category,
                                                   &overwrite_default );
+            bool basic_overwrite_default;
+            const action_attributes &basic_attributes = inp_mngr.get_action_attributes( action_id,
+                    ctxt->category, &basic_overwrite_default, true );
 
             ImGui::TableNextColumn();
             ImGui::Text( " " );
@@ -649,13 +653,13 @@ void keybindings_ui::draw_controls()
             if( status == s_add_global && overwrite_default ) {
                 // We're trying to add a global, but this action has a local
                 // defined, so gray out the invlet.
-                key_text = colorize( string_format( "%c ", invlet ), c_dark_gray );
+                key_text = colorize( string_format( "%c", invlet ), c_dark_gray );
             } else if( status == s_add || status == s_add_global || status == s_remove ) {
-                key_text = colorize( string_format( "%c ", invlet ), c_light_blue );
+                key_text = colorize( string_format( "%c", invlet ), c_light_blue );
             } else if( status == s_execute ) {
-                key_text = colorize( string_format( "%c ", invlet ), c_white );
+                key_text = colorize( string_format( "%c", invlet ), c_white );
             } else {
-                key_text = "  ";
+                key_text = " ";
             }
             nc_color col;
             if( attributes.input_events.empty() ) {
@@ -664,6 +668,13 @@ void keybindings_ui::draw_controls()
                 col = i == size_t( highlight_row_index ) ? h_local_key : local_key;
             } else {
                 col = i == size_t( highlight_row_index ) ? h_global_key : global_key;
+            }
+            if( overwrite_default != basic_overwrite_default
+                || attributes.input_events != basic_attributes.input_events
+              ) {
+                key_text += "*";
+            } else {
+                key_text += " ";
             }
             key_text += string_format( "%s:", ctxt->get_action_name( action_id ) );
             bool is_selected = false;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

reintroduce https://github.com/CleverRaven/Cataclysm-DDA/pull/71060 which was removed in 
2024-02-22 09h 4f2081ae51 Converting keybindings screen to ImGui

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add the missing bits, some bits were already there

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Compiled, didn't do all the tests as in original PR, but it looks good.
![image](https://github.com/katemonster33/Cataclysm-DDA/assets/13402666/4eb7acb2-b4db-4be4-98b4-6ae4a8e06df5)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I recommend rebasing like this:
It runs into no conflicts and directs the fix to the commit which needs it.

```git
pick 42cf9d065c Committing ImGui v1.89.6 with the SDL2 and SDL2-renderer backends.
pick cfcbfe7711 Added ImTui v1.81, built against (modified) ImGui v1.81
pick 6e4be1778f Adding support for togglable ASCII drawing within ImGui, without these changes then text and various widgets do not draw properly.
pick 22c5ced966 Changed the include statements for SDL to be more platform-independent.
pick 59ba04dd03 Rewrote ImTui to allow for drawing of ImTui windows alongside other ncurses-drawn objects. Otherwise everything but ImTui windows are blank.
pick c2e90e91d6 Added support for building ImGui with Make/CMake.
pick ac3c4d8ba9 Added support for building ImGui on Windows.
pick 4c24c255a6 Added imgui helper file, added support for loading ImGui from CDDA.
pick f9897fa842 removed draw_imgui parameter from ui_adaptor::redraw_invalidated, removed some extra imgui-specific drawing code.
pick c992a76f46 Added documentation regarding ImGui and currently implemented screens
pick 8d32b4dfff Update src/cata_imgui.cpp headers based on suggestion
pick f0b440acc0 Migrating query_popup and static_popup to imgui.
pick 02ea511f32 Converting keybindings screen to ImGui
f 7110583c47 display custom keybind with *, again

pick 0e07cab4f8 fix some errors and warnings when building with clang
pick f2215a06e5 ImGui widgets record their dimensions, invalidate lower uis
pick 75e0cd2ecc remove terminal_framebuffer optimization
pick 5e9b77c80a Modifying Gradle build for ImGui
pick ff3abac8e2 Fixing the issue where the wrong ImGui window can end up in the front.

# Rebase dd7a836991..7110583c47 onto dd7a836991 (19 commands)
#
# Commands:
# p, pick <commit> = use commit
# r, reword <commit> = use commit, but edit the commit message
# e, edit <commit> = use commit, but stop for amending
# s, squash <commit> = use commit, but meld into previous commit
# f, fixup [-C | -c] <commit> = like "squash" but keep only the previous
#                    commit's log message, unless -C is used, in which case
#                    keep only this commit's message; -c is same as -C but
#                    opens the editor
# x, exec <command> = run command (the rest of the line) using shell
# b, break = stop here (continue rebase later with 'git rebase --continue')
# d, drop <commit> = remove commit
# l, label <label> = label current HEAD with a name
# t, reset <label> = reset HEAD to a label
# m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]
# .       create a merge commit using the original merge commit's
# .       message (or the oneline, if no original merge commit was
# .       specified); use -c <commit> to reword the commit message
#
# These lines can be re-ordered; they are executed from top to bottom.
#
# If you remove a line here THAT COMMIT WILL BE LOST.
#
# However, if you remove everything, the rebase will be aborted.
#

```

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
