### PR TITLE
Reload furniture multi ammo types

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4329,15 +4329,6 @@ const itype *furn_t::crafting_pseudo_item_type() const
     return item::find_type( crafting_pseudo_item );
 }
 
-const itype *furn_t::crafting_ammo_item_type() const
-{
-    const itype *pseudo = crafting_pseudo_item_type();
-    if( pseudo && pseudo->tool && !pseudo->tool->ammo_id.empty() ) {
-        return item::find_type( ammotype( *pseudo->tool->ammo_id.begin() )->default_ammotype() );
-    }
-    return nullptr;
-}
-
 const std::vector<const itype *> furn_t::crafting_ammo_item_types() const
 {
     const itype *pseudo = crafting_pseudo_item_type();
@@ -6627,7 +6618,7 @@ void iexamine::smoker_options( Character &you, const tripoint &examp )
 
     const furn_t &f = here.furn( examp ).obj();
     const itype *type = f.crafting_pseudo_item_type();
-    const itype *ammo = f.crafting_ammo_item_type();
+    const itype *ammo = f.crafting_ammo_item_types().front();
     const bool empty = f_volume == 0_ml;
     const bool full = f_volume >= sm_rack::MAX_FOOD_VOLUME;
     const bool full_portable = f_volume >= sm_rack::MAX_FOOD_VOLUME_PORTABLE;

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -669,8 +669,7 @@ struct furn_t : map_data_common_t {
 
     // May return NULL
     const itype *crafting_pseudo_item_type() const;
-    // May return NULL
-    const itype *crafting_ammo_item_type() const;
+    // May return an empty container if no valid ammotype
     const std::vector<const itype *> crafting_ammo_item_types() const;
 
     furn_t();


### PR DESCRIPTION
This is working at least for the forge. You should be able to put my commits after your changes to using single ammotype at a time. (If you try to use 2 ammotypes at once it'll fail to put the 2nd one into the pseudo item, causing an error and some of your ammo to be missing).

